### PR TITLE
Add usage information

### DIFF
--- a/boringproxy.go
+++ b/boringproxy.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/caddyserver/certmagic"
 	"io"
 	"log"
 	"net"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/caddyserver/certmagic"
 )
 
 type BoringProxyConfig struct {
@@ -40,7 +41,12 @@ func Listen() {
 	adminDomain := flagSet.String("admin-domain", "", "Admin Domain")
 	sshServerPort := flagSet.Int("ssh-server-port", 22, "SSH Server Port")
 	certDir := flagSet.String("cert-dir", "", "TLS cert directory")
-	flagSet.Parse(os.Args[2:])
+	err := flagSet.Parse(os.Args[2:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: parsing flags: %s\n", os.Args[0], err)
+	}
+
+	log.Println("Starting up")
 
 	webUiDomain := *adminDomain
 
@@ -64,7 +70,7 @@ func Listen() {
 	//certmagic.DefaultACME.CA = certmagic.LetsEncryptStagingCA
 	certConfig := certmagic.NewDefault()
 
-	err := certConfig.ManageSync([]string{config.WebUiDomain})
+	err = certConfig.ManageSync([]string{config.WebUiDomain})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client.go
+++ b/client.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/caddyserver/certmagic"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"io/ioutil"
 	"log"
@@ -18,6 +16,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/caddyserver/certmagic"
+	"golang.org/x/crypto/ssh"
 )
 
 type BoringProxyClient struct {
@@ -42,7 +43,10 @@ func NewBoringProxyClient() *BoringProxyClient {
 	certDir := flagSet.String("cert-dir", "", "TLS cert directory")
 	acmeEmail := flagSet.String("acme-email", "", "Email for ACME (ie Let's Encrypt)")
 	dnsServer := flagSet.String("dns-server", "", "Custom DNS server")
-	flagSet.Parse(os.Args[2:])
+	err := flagSet.Parse(os.Args[2:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: parsing flags: %s\n", os.Args[0], err)
+	}
 
 	if *dnsServer != "" {
 		net.DefaultResolver = &net.Resolver{
@@ -63,7 +67,6 @@ func NewBoringProxyClient() *BoringProxyClient {
 	// running on a machine where 443 isn't bound, so we need a different
 	// port to hack around this. See here for more details:
 	// https://github.com/caddyserver/certmagic/issues/111
-	var err error
 	certmagic.HTTPSPort, err = randomOpenPort()
 	if err != nil {
 		log.Fatal("Failed get random port for TLS challenges")

--- a/main.go
+++ b/main.go
@@ -2,29 +2,36 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
-func main() {
+const usage = `Usage: %s [command] [flags]
 
+Commands:
+    server       Start a new server.
+    client       Connect to a server.
+
+Use "%[1]s command -h" for a list of flags for the command.
+`
+
+func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("Invalid arguments")
+		fmt.Fprintln(os.Stderr, os.Args[0]+": Need a command")
+		fmt.Printf(usage, os.Args[0])
 		os.Exit(1)
 	}
 
 	command := os.Args[1]
-
 	switch command {
+	case "help", "-h", "--help", "-help":
+		fmt.Printf(usage, os.Args[0])
 	case "server":
-		log.Println("Starting up")
 		Listen()
-
 	case "client":
 		client := NewBoringProxyClient()
 		client.RunPuppetClient()
 	default:
-		fmt.Println("Invalid command " + command)
+		fmt.Fprintln(os.Stderr, os.Args[0]+": Invalid command "+command)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Before not giving any command didn't really give much feedback beyond
"invalid arguments". This adds a basic usage message, and tells people
that you can use "boringproxy server -h".

I moved the "Starting up" log message because otherwise that would get
printed when asking for "server -h".

I also added error checks for the flag parsing; I think this isn't
*strictly* needed, but I remember running in to problems once by
omitting it (although I've forgotten what that problem was, exactly).