### PR TITLE
Use "fmt.Print()" instead of "log.Print()" when asking for admin domain

### DIFF
--- a/boringproxy.go
+++ b/boringproxy.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/caddyserver/certmagic"
 	"io"
 	"log"
 	"net"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/caddyserver/certmagic"
 )
 
 type BoringProxyConfig struct {
@@ -46,7 +47,7 @@ func Listen() {
 
 	if *adminDomain == "" {
 		reader := bufio.NewReader(os.Stdin)
-		log.Print("Enter Admin Domain: ")
+		fmt.Print("Enter Admin Domain: ")
 		text, _ := reader.ReadString('\n')
 		webUiDomain = strings.TrimSpace(text)
 	}


### PR DESCRIPTION
When using "boringproxy server" it asks for the admin domain. All grand,
but it looks rather strange:

	2021/01/05 22:11:05 Starting up
	2021/01/05 22:11:05 Enter Admin Domain:
	[cursor is here]

It wasn't really clear to me this was asking a question, as it includes
the date like a log message and the cursor is on the next line.

So, change it to just fmt.Print()

Maybe the "starting up" should also be moved a bit further down, but
that would conflict with my other PR 🙃