### PR TITLE
proxyRequest with ClientAddress and not localhost

### DIFF
--- a/boringproxy.go
+++ b/boringproxy.go
@@ -274,7 +274,7 @@ func Listen() {
 				return
 			}
 
-			proxyRequest(w, r, tunnel, httpClient, tunnel.TunnelPort, *behindProxy)
+			proxyRequest(w, r, tunnel, httpClient, "localhost", tunnel.TunnelPort, *behindProxy)
 		}
 	})
 

--- a/client.go
+++ b/client.go
@@ -297,7 +297,7 @@ func (c *Client) BoreTunnel(ctx context.Context, tunnel Tunnel) error {
 		httpMux := http.NewServeMux()
 
 		httpMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			proxyRequest(w, r, tunnel, c.httpClient, tunnel.ClientPort, c.behindProxy)
+			proxyRequest(w, r, tunnel, c.httpClient, tunnel.ClientAddress, tunnel.ClientPort, c.behindProxy)
 		})
 
 		httpServer := &http.Server{

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func proxyRequest(w http.ResponseWriter, r *http.Request, tunnel Tunnel, httpClient *http.Client, port int, behindProxy bool) {
+func proxyRequest(w http.ResponseWriter, r *http.Request, tunnel Tunnel, httpClient *http.Client, address string, port int, behindProxy bool) {
 
 	if tunnel.AuthUsername != "" || tunnel.AuthPassword != "" {
 		username, password, ok := r.BasicAuth()
@@ -29,9 +29,7 @@ func proxyRequest(w http.ResponseWriter, r *http.Request, tunnel Tunnel, httpCli
 
 	downstreamReqHeaders := r.Header.Clone()
 
-	// TODO: should probably pass in address instead of using localhost,
-	// mostly for client-terminated TLS
-	upstreamAddr := fmt.Sprintf("localhost:%d", port)
+	upstreamAddr := fmt.Sprintf("%s:%d", address, port)
 	upstreamUrl := fmt.Sprintf("http://%s%s", upstreamAddr, r.URL.RequestURI())
 
 	upstreamReq, err := http.NewRequest(r.Method, upstreamUrl, r.Body)


### PR DESCRIPTION
Currently tunnels can only be made to ports on client machine, this is due to a hardcoded "localhost" in proxyRequest for upstreamAddr.

Changes to code adds 'address' param to function proxyRequest and pass it to variable upstreamAddr

Since the hardcoded 'localhost' was required for server functionality in boringproxy.go, I passed the hardcoded 'localhost' string in the function call in boringproxy.go:277

During my tests I was able to create tunnels to ports on the client device as well as ports reachable by the client machine.