### PR TITLE
accept-ca-terms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN if [[ "ORIGIN" == 'remote' ]] ; then git clone --depth 1 --branch "${BRANCH}
 COPY go.* ./
 RUN go mod download
 COPY . .
-RUN export VERSION='2'
 
 RUN cd cmd/boringproxy && CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} \
 	go build -ldflags "-X main.Version=${VERSION}" \
@@ -25,6 +24,7 @@ RUN cd cmd/boringproxy && CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} \
 
 FROM scratch
 EXPOSE 80 443
+WORKDIR /storage
 
 COPY --from=builder /build/cmd/boringproxy/boringproxy /
 

--- a/boringproxy.go
+++ b/boringproxy.go
@@ -56,6 +56,7 @@ func Listen() {
 	behindProxy := flagSet.Bool("behind-proxy", false, "Whether we're running behind another reverse proxy")
 	acmeEmail := flagSet.String("acme-email", "", "Email for ACME (ie Let's Encrypt)")
 	acmeUseStaging := flagSet.Bool("acme-use-staging", false, "Use ACME (ie Let's Encrypt) staging servers")
+	acceptCATerms := flagSet.Bool("accept-ca-terms", false, "Automatically accept CA terms")
 	err := flagSet.Parse(os.Args[2:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: parsing flags: %s\n", os.Args[0], err)
@@ -105,6 +106,11 @@ func Listen() {
 
 	if *acmeEmail != "" {
 		certmagic.DefaultACME.Email = *acmeEmail
+	}
+
+	if *acceptCATerms {
+		certmagic.DefaultACME.Agreed  = true
+		log.Print(fmt.Sprintf("Automatic agreement to CA terms with email (%s)", *acmeEmail))
 	}
 
 	if *acmeUseStaging {

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -4,6 +4,9 @@
 
 Edit docker-compose.yml and change the following under **commands** for service **boringproxy**
 - bp.example.com: your admin domain
+- your-email-address: the email address to register with Let's Encrypt
+
+***Since the -accept-ca-terms flag is set in the compose file, this will automatically accept terms and conditions of Let's Encrypt.***
 
 ## Build image from source and run server in docker
 You can build the image from source. This requires that you clone the GitHub repo and start docker using the compose command below:

--- a/docker/server/docker-compose.yml
+++ b/docker/server/docker-compose.yml
@@ -7,11 +7,13 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - data:/opt/boringproxy/
-    command: ["server", "-admin-domain", "bp.example.com", "-cert-dir", "/certmagic"]
+      - storage:/storage/
+      - ssh://.ssh
+      - /etc/ssl/certs/:/etc/ssl/certs/:ro
+    command: ["server", "-admin-domain", "bp.example.com", "-acme-email", "your-email-address", "-accept-ca-terms", "-cert-dir", "/storage/certmagic", "-print-login"]
     environment:
       USER: "root"
 
 volumes:
-  data:
-  certmagic:
+  storage:
+  ssh:


### PR DESCRIPTION
Changes:

- removed "RUN export VERSION='2'" from Dockerfile, this was accidentally left over from previous testing
- added a WORKDIR for image
- added acceptCATerms to automatically accept terms when starting docker container
- updated README to reflect changes
- updated docker-compose to reflect changes