### PR TITLE
Implement overriding SSH server per tunnel

### DIFF
--- a/api.go
+++ b/api.go
@@ -378,6 +378,22 @@ func (a *Api) CreateTunnel(tokenData TokenData, params url.Values) (*Tunnel, err
 		return nil, errors.New("Invalid tls-termination parameter")
 	}
 
+	sshServerAddr := a.db.GetAdminDomain()
+	sshServerAddrParam := params.Get("ssh-server-addr")
+	if sshServerAddrParam != "" {
+		sshServerAddr = sshServerAddrParam
+	}
+
+	sshServerPort := a.config.SshServerPort
+	sshServerPortParam := params.Get("ssh-server-port")
+	if sshServerPortParam != "" {
+		var err error
+		sshServerPort, err = strconv.Atoi(sshServerPortParam)
+		if err != nil {
+			return nil, errors.New("Invalid ssh-server-port parameter")
+		}
+	}
+
 	request := Tunnel{
 		Domain:           domain,
 		Owner:            owner,
@@ -389,6 +405,8 @@ func (a *Api) CreateTunnel(tokenData TokenData, params url.Values) (*Tunnel, err
 		AuthUsername:     username,
 		AuthPassword:     password,
 		TlsTermination:   tlsTerm,
+		ServerAddress:    sshServerAddr,
+		ServerPort:       sshServerPort,
 	}
 
 	tunnel, err := a.tunMan.RequestCreateTunnel(request)

--- a/client.go
+++ b/client.go
@@ -276,6 +276,7 @@ func (c *Client) BoreTunnel(ctx context.Context, tunnel Tunnel) error {
 	}
 
 	sshHost := fmt.Sprintf("%s:%d", tunnel.ServerAddress, tunnel.ServerPort)
+	fmt.Println(sshHost)
 	client, err := ssh.Dial("tcp", sshHost, config)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Failed to dial: ", err))

--- a/templates/edit_tunnel.tmpl
+++ b/templates/edit_tunnel.tmpl
@@ -59,6 +59,15 @@
        </div>
      </div>
 
+     <div class='input'>
+       <label for="ssh-server-addr">Override SSH Server Address:</label>
+       <input type="text" id="ssh-server-addr" name="ssh-server-addr">
+     </div>
+     <div class='input'>
+       <label for="ssh-server-port">Override SSH Server Port:</label>
+       <input type="text" id="ssh-server-port" name="ssh-server-port">
+     </div>
+
      <button class='button' type="submit">Submit</button>
 
   </form>

--- a/tunnel_manager.go
+++ b/tunnel_manager.go
@@ -98,8 +98,6 @@ func (m *TunnelManager) RequestCreateTunnel(tunReq Tunnel) (Tunnel, error) {
 		return Tunnel{}, err
 	}
 
-	tunReq.ServerAddress = m.db.GetAdminDomain()
-	tunReq.ServerPort = m.config.SshServerPort
 	tunReq.ServerPublicKey = ""
 	tunReq.Username = m.user.Username
 	tunReq.TunnelPrivateKey = privKey


### PR DESCRIPTION
This lets you use a proxy for connecting to the SSH server, which
is useful on networks that block SSH/port 22. For example you can
use the boringproxy tuntls command to create a proxy that will
tunnel the client's SSH connections over TLS to the server.

It's all very meta and forces at least double encryption, but it
could be useful.