### PR TITLE
Added support for ssh-Ed25519. Removed ssh-rsa.

### DIFF
--- a/tunnel_manager.go
+++ b/tunnel_manager.go
@@ -2,20 +2,21 @@ package boringproxy
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/caddyserver/certmagic"
-	"golang.org/x/crypto/ssh"
 	"io/ioutil"
 	"log"
+	mrand "math/rand"
 	"os"
 	"os/user"
 	"strings"
 	"sync"
+
+	"github.com/caddyserver/certmagic"
+	"golang.org/x/crypto/ssh"
 )
 
 type TunnelManager struct {
@@ -217,12 +218,95 @@ func (m *TunnelManager) addToAuthorizedKeys(domain string, port int, allowExtern
 	return privKey, nil
 }
 
-// Adapted from https://stackoverflow.com/a/34347463/943814
-// MakeSSHKeyPair make a pair of public and private keys for SSH access.
-// Public key is encoded in the format for inclusion in an OpenSSH authorized_keys file.
-// Private Key generated is PEM encoded
+/* X509 can not marshall a ed25519 key for some reason, even in 2022.
+The following code is from mikesmitty/edkey */
+
+/* Writes ed25519 private keys into the new OpenSSH private key format.
+I have no idea why this isn't implemented anywhere yet, you can do seemingly
+everything except write it to disk in the OpenSSH private key format. */
+func MarshalED25519PrivateKey(key ed25519.PrivateKey) []byte {
+	// Add our key header (followed by a null byte)
+	magic := append([]byte("openssh-key-v1"), 0)
+
+	var w struct {
+		CipherName   string
+		KdfName      string
+		KdfOpts      string
+		NumKeys      uint32
+		PubKey       []byte
+		PrivKeyBlock []byte
+	}
+
+	// Fill out the private key fields
+	pk1 := struct {
+		Check1  uint32
+		Check2  uint32
+		Keytype string
+		Pub     []byte
+		Priv    []byte
+		Comment string
+		Pad     []byte `ssh:"rest"`
+	}{}
+
+	// Set our check ints
+	ci := mrand.Uint32()
+	pk1.Check1 = ci
+	pk1.Check2 = ci
+
+	// Set our key type
+	pk1.Keytype = ssh.KeyAlgoED25519
+
+	// Add the pubkey to the optionally-encrypted block
+	pk, ok := key.Public().(ed25519.PublicKey)
+	if !ok {
+		//fmt.Fprintln(os.Stderr, "ed25519.PublicKey type assertion failed on an ed25519 public key. This should never ever happen.")
+		return nil
+	}
+	pubKey := []byte(pk)
+	pk1.Pub = pubKey
+
+	// Add our private key
+	pk1.Priv = []byte(key)
+
+	// Might be useful to put something in here at some point
+	pk1.Comment = ""
+
+	// Add some padding to match the encryption block size within PrivKeyBlock (without Pad field)
+	// 8 doesn't match the documentation, but that's what ssh-keygen uses for unencrypted keys. *shrug*
+	bs := 8
+	blockLen := len(ssh.Marshal(pk1))
+	padLen := (bs - (blockLen % bs)) % bs
+	pk1.Pad = make([]byte, padLen)
+
+	// Padding is a sequence of bytes like: 1, 2, 3...
+	for i := 0; i < padLen; i++ {
+		pk1.Pad[i] = byte(i + 1)
+	}
+
+	// Generate the pubkey prefix "\0\0\0\nssh-ed25519\0\0\0 "
+	prefix := []byte{0x0, 0x0, 0x0, 0x0b}
+	prefix = append(prefix, []byte(ssh.KeyAlgoED25519)...)
+	prefix = append(prefix, []byte{0x0, 0x0, 0x0, 0x20}...)
+
+	// Only going to support unencrypted keys for now
+	w.CipherName = "none"
+	w.KdfName = "none"
+	w.KdfOpts = ""
+	w.NumKeys = 1
+	w.PubKey = append(prefix, pubKey...)
+	w.PrivKeyBlock = ssh.Marshal(pk1)
+
+	magic = append(magic, ssh.Marshal(w)...)
+
+	return magic
+}
+
+/* end */
+
+// Generate SSH key pair using ed25519
+// This will invalidate any setup using 0.9.1-beta or below!
 func MakeSSHKeyPair() (string, string, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return "", "", err
 	}
@@ -230,13 +314,16 @@ func MakeSSHKeyPair() (string, string, error) {
 	// generate and write private key as PEM
 	var privKeyBuf strings.Builder
 
-	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+	privateKeyPEM := &pem.Block{
+		Type:  "OPENSSH PRIVATE KEY",
+		Bytes: MarshalED25519PrivateKey(privateKey),
+	}
 	if err := pem.Encode(&privKeyBuf, privateKeyPEM); err != nil {
 		return "", "", err
 	}
 
 	// generate and write public key
-	pub, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	pub, err := ssh.NewPublicKey(publicKey)
 	if err != nil {
 		return "", "", err
 	}

--- a/ui_handler.go
+++ b/ui_handler.go
@@ -3,12 +3,15 @@ package boringproxy
 import (
 	"embed"
 	"encoding/base64"
+
 	//"encoding/json"
 	"fmt"
-	qrcode "github.com/skip2/go-qrcode"
 	"html/template"
 	"io"
 	"net/http"
+
+	qrcode "github.com/skip2/go-qrcode"
+
 	//"net/url"
 	//"os"
 	"strings"
@@ -209,7 +212,7 @@ func (h *WebUiHandler) handleWebUiRequest(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		w.Header().Set("Content-Disposition", "attachment; filename=id_rsa")
+		w.Header().Set("Content-Disposition", "attachment; filename=id_ed25519")
 		io.WriteString(w, tun.TunnelPrivateKey)
 
 	case "/add-token-client":


### PR DESCRIPTION
Updated tunnel_manager.go and ui_handler.go to support ssh-Ed25519 keys. This does remove support for ssh-rsa however. If a client / server connection has been generated using ssh-rsa, this will to be re-generated though the web UI for new keys to be created.