### PR TITLE
Update build_release.sh to include darwin/arm64

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -22,6 +22,7 @@ cd ./cmd/boringproxy
 ../../scripts/build_arch.sh openbsd arm
 ../../scripts/build_arch.sh openbsd arm64
 ../../scripts/build_arch.sh windows 386 .exe
+../../scripts/build_arch.sh darwin arm64
 
 mv build ../../
 cd ../../


### PR DESCRIPTION
With the release binaries for M1 mac, users will find it more convenient to use `boringproxy`. Actually, I am one of them.