### PR TITLE
Added IP restriction option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist
+boringproxy_db.json

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
@@ -237,7 +238,7 @@ func (c *Client) SyncTunnels(ctx context.Context, serverTunnels map[string]Tunne
 			log.Println("New tunnel", k)
 			c.tunnels[k] = newTun
 			bore = true
-		} else if newTun != tun {
+		} else if !reflect.DeepEqual(newTun, tun) {
 			log.Println("Restart tunnel", k)
 			c.cancelFuncsMutex.Lock()
 			c.cancelFuncs[k]()

--- a/database.go
+++ b/database.go
@@ -56,10 +56,11 @@ type Tunnel struct {
 
 	// TODO: These are not used by clients and possibly shouldn't be
 	// returned in API calls.
-	Owner        string `json:"owner"`
-	ClientName   string `json:"client_name"`
-	AuthUsername string `json:"auth_username"`
-	AuthPassword string `json:"auth_password"`
+	Owner        string   `json:"owner"`
+	ClientName   string   `json:"client_name"`
+	AuthUsername string   `json:"auth_username"`
+	AuthPassword string   `json:"auth_password"`
+	IPsAllowed   []string `json:"ips_allowed"`
 }
 
 func NewDatabase(path string) (*Database, error) {
@@ -158,7 +159,7 @@ func (d *Database) AddToken(owner, client string) (string, error) {
 
 	token, err := genRandomCode(32)
 	if err != nil {
-		return "", errors.New("Could not generat token")
+		return "", errors.New("Could not generate token")
 	}
 
 	d.Tokens[token] = TokenData{

--- a/templates/edit_tunnel.tmpl
+++ b/templates/edit_tunnel.tmpl
@@ -58,6 +58,16 @@
          <input type="password" id="password" name="password">
        </div>
      </div>
+     
+     <div class='input'>
+       <label for="ip-restricted">IP restriction:</label>
+       <input type="checkbox" id="ip-restricted" name="ip-restricted">
+
+       <div id='allowed-ips-input'>
+         <label for="allowed-ips">Allowed IPs (one per line):</label>
+         <textarea id="allowed-ips" name="allowed-ips" cols="40" rows="5"></textarea>
+       </div>
+     </div>
 
      <div class='input'>
        <label for="ssh-server-addr">Override SSH Server Address:</label>

--- a/templates/styles.tmpl
+++ b/templates/styles.tmpl
@@ -215,6 +215,14 @@ main {
   display: block;
 }
 
+#allowed-ips-input {
+  display: none;
+}
+
+#ip-restricted:checked ~ #allowed-ips-input {
+  display: block;
+}
+
 .token-adder {
   padding: 5px;
   display: flex;


### PR DESCRIPTION
Hi!

As discussed in https://forum.indiebits.io/t/issues-with-basic-authentication/256/4, I'd like to get an honest first opinion on this. I've commented the PR to help you navigate through it. 

One blocking I've encountered is that for `client` tls terminated tunnels, the feature blocks the requests made from let's encrypt to validate the domain. Unfortunately, let's encrypt does not publish a list of IPs that we could systematically add so the only option I see would be to use [dns validation](https://github.com/caddyserver/certmagic#dns-challenge), or move the cert generation/renewal to the server and transfer it to the clients but it would be a lot more work. Even DNS validation would be complicated since dns providers are plentiful and all require a different pluggable golang module. Any idea here?

This is what the UI looks like : 
<img width="701" alt="image" src="https://user-images.githubusercontent.com/3722096/223732324-1a5a6b1e-989f-48dc-bff4-a7c68e7b19a2.png">
When checking the box : 
<img width="332" alt="image" src="https://user-images.githubusercontent.com/3722096/223732524-ff6d131f-cf4b-45d7-b817-d5467947a932.png">

Disclaimer, I'm not a golang expert and I've tried following the code style of the existing codebase. 